### PR TITLE
fix xls-workshop design

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -25,20 +25,20 @@ documentation:
   clock_hz:     0       # Clock frequency in Hz (if required) we are expecting max clock frequency to be ~6khz. Provided on input 0.
   picture:      ""      # relative path to a picture in your repository
   inputs:               # a description of what the inputs do
-    - clock
-    - reset
-    - none
-    - none
-    - none
-    - none
-    - none
-    - none
+    - left_operand_bit0
+    - left_operand_bit1
+    - left_operand_bit2
+    - left_operand_bit3
+    - right_operand_bit0
+    - right_operand_bit1
+    - right_operand_bit2
+    - right_operand_bit3
   outputs:
-    - out[0]         # a description of what the outputs do
-    - out[1]
-    - out[2]
-    - out[3]
-    - out[4]
-    - out[5]
-    - out[6]
-    - out[7]
+    - multiplication_result_bit0
+    - multiplication_result_bit1
+    - multiplication_result_bit2
+    - multiplication_result_bit3
+    - multiplication_result_bit4
+    - multiplication_result_bit5
+    - multiplication_result_bit6
+    - multiplication_result_bit7

--- a/openlane/tiny_user_project/config.json
+++ b/openlane/tiny_user_project/config.json
@@ -1,5 +1,5 @@
 {
-    "DESIGN_NAME": "user_module",
+    "DESIGN_NAME": "tiny_user_project",
     "DESIGN_IS_CORE": 0,
     "VERILOG_FILES": "dir::../../verilog/rtl/user_module.v",
     "CLOCK_PERIOD": 10,


### PR DESCRIPTION
- set top level module back to `tiny_user_project`
- document input and output pins